### PR TITLE
Use `g:theprimeagen_colorscheme` to change colorscheme

### DIFF
--- a/nvim/.config/nvim/plugin/colors.vim
+++ b/nvim/.config/nvim/plugin/colors.vim
@@ -1,4 +1,4 @@
-let g:theprimeagen_colorscheme = "gruvbox"
+let g:theprimeagen_colorscheme = 'gruvbox'
 fun! ColorMyPencils()
     let g:gruvbox_contrast_dark = 'hard'
     if exists('+termguicolors')
@@ -11,8 +11,7 @@ fun! ColorMyPencils()
     if has('nvim')
         call luaeval('vim.cmd("colorscheme " .. _A[1])', [g:theprimeagen_colorscheme])
     else
-        " TODO: What the way to use g:theprimeagen_colorscheme
-        colorscheme gruvbox
+        exe 'colorscheme' g:theprimeagen_colorscheme
     endif
 
     highlight ColorColumn ctermbg=0 guibg=grey


### PR DESCRIPTION
Hi prime,
I just want to help you with one of your `TODO`. You can test this out first inside of vim/neovim, just to be sure.

You can also use `exe 'colorscheme ' . g:theprimeagen_colorscheme` if
you prefer it that way. Also, using `"` and `'` has different meaning in
vim script. I assume you want to use string, so I changed it to
`'gruvbox'` instead of `"gruvbox"`.