### PR TITLE
Improve Tmux Sessionizer

### DIFF
--- a/bin/.local/bin/tmux-sessionizer
+++ b/bin/.local/bin/tmux-sessionizer
@@ -13,8 +13,15 @@ fi
 selected_name=$(basename "$selected" | tr . _)
 tmux_running=$(pgrep tmux)
 
-if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
+if [ ! $tmux_running ]; then
     tmux new-session -s $selected_name -c $selected
+    exit 0
+fi
+
+# If there is at least a tmux server running
+# And if you're not inside tmux, then either attach to the session or create it:
+if [ -z "$TMUX" ]; then
+    tmux new-session -A -s $selected_name -c $selected 
     exit 0
 fi
 

--- a/bin/.local/bin/tmux-sessionizer
+++ b/bin/.local/bin/tmux-sessionizer
@@ -15,14 +15,14 @@ tmux_running=$(pgrep tmux)
 
 if [ ! $tmux_running ]; then
     tmux new-session -s $selected_name -c $selected
-    exit 0
+    return 0
 fi
 
 # If there is at least a tmux server running
 # And if you're not inside tmux, then either attach to the session or create it:
 if [ -z "$TMUX" ]; then
     tmux new-session -A -s $selected_name -c $selected 
-    exit 0
+    return 0
 fi
 
 if ! tmux has-session -t $selected_name 2> /dev/null; then


### PR DESCRIPTION
This improvement will let you handle the case in witch the tmux server is already running but you are in the terminal outside tmux. 
In that case it will create the session or attached it (if the session already exist) thanks to the option `-A`.
I already tested id and it worked


PS: After finished your course (btw amazing course thanks again) I managed to achieve a more complex sessionizer, one in which it either let me select a path or it let me give a name (with option -n name) and then open the session in the current folder, I just published in this gist: https://gist.github.com/fsgreco/be959f9cc43600db8d9ea50941f16f03