### PR TITLE
To match exact strings

### DIFF
--- a/bin/.local/scripts/tmux-cht.sh
+++ b/bin/.local/scripts/tmux-cht.sh
@@ -6,7 +6,7 @@ fi
 
 read -p "Enter Query: " query
 
-if grep -qs "$selected" ~/.tmux-cht-languages; then
+if grep -qsw "$selected" ~/.tmux-cht-languages; then
     query=`echo $query | tr ' ' '+'`
     tmux neww bash -c "echo \"curl cht.sh/$selected/$query/\" & curl cht.sh/$selected/$query & while [ : ]; do sleep 1; done"
 else


### PR DESCRIPTION
There was this edge case where `cp` would match against `cpp` and the grep condition to check for languages would pass. This should fix the issue.