### PR TITLE
chore(nvim): remove duplicate remaps

### DIFF
--- a/nvim/.config/nvim/after/plugin/keymap/init.lua
+++ b/nvim/.config/nvim/after/plugin/keymap/init.lua
@@ -39,8 +39,6 @@ nmap("<leader>Y", "\"+Y")
 nnoremap("<leader>d", "\"_d")
 vnoremap("<leader>d", "\"_d")
 
-vnoremap("<leader>d", "\"_d")
-
 -- This is going to get me cancelled
 inoremap("<C-c>", "<Esc>")
 


### PR DESCRIPTION
The remap "vnoremap("<leader>d", "\"_d")" is set twice