### PR TITLE
Using nvim (less inside terminal mode) as pager to view the cht.sh results

### DIFF
--- a/bin/.local/scripts/tmux-cht.sh
+++ b/bin/.local/scripts/tmux-cht.sh
@@ -6,17 +6,16 @@
 
 fuzzy_finder=fzf  # use either fzf or sk
 
+# Pressing <esc> exits terminal mode and moves cursor to the middle of the screen
+# Pressing q quits nvim inside normal and terminal mode
 nvim_options="\
-    -c \"nnoremap i :echo 'i disabled!'<CR>\" \
-    -c \"nnoremap I :echo 'I disabled!'<CR>\" \
-    -c \"nnoremap a :echo 'a disabled!'<CR>\" \
-    -c \"nnoremap A :echo 'A disabled!'<CR>\" \
-    -c \"nnoremap p :echo 'p disabled!'<CR>\" \
-    -c \"nnoremap P :echo 'P disabled!'<CR>\" \
-    -c \"nnoremap q :q!<CR>\""
+    -c \"nnoremap q :q!<CR>\" \
+    -c \"tnoremap <esc> :<C-\\><C-n>M\" \
+    -c \"tnoremap q :<C-\\><C-n>:q!<CR>\""
 
 # Using bat inside the terminal results in line wraps to dynamically adjust
 # when changing the windown size
+#bat_options=""
 bat_options="\
     --paging=always \
     --style=plain"
@@ -37,4 +36,5 @@ else
 fi
 
 tmux neww -n "$url" bash -c "nvim $nvim_options \
-    +'ter curl --no-progress-meter $url | bat $bat_options'"
+    +'ter curl --no-progress-meter $url | bat $bat_options'"  # +'call feedkeys(\"i\")'"
+

--- a/bin/.local/scripts/tmux-cht.sh
+++ b/bin/.local/scripts/tmux-cht.sh
@@ -4,7 +4,7 @@
 # - fuzzy finder: either fzf or sk
 # - bat: as cat replacement - is being used as pager inside nvim terminal
 
-fuzzy_finder=sk  # use either fzf or sk
+fuzzy_finder=fzf  # use either fzf or sk
 
 nvim_options="\
     -c \"nnoremap i :echo 'i disabled!'<CR>\" \

--- a/bin/.local/scripts/tmux-cht.sh
+++ b/bin/.local/scripts/tmux-cht.sh
@@ -1,15 +1,40 @@
 #!/usr/bin/env bash
-selected=`cat ~/.tmux-cht-languages ~/.tmux-cht-command | fzf`
+
+# Prerequisites:
+# - fuzzy finder: either fzf or sk
+# - bat: as cat replacement - is being used as pager inside nvim terminal
+
+fuzzy_finder=sk  # use either fzf or sk
+
+nvim_options="\
+    -c \"nnoremap i :echo 'i disabled!'<CR>\" \
+    -c \"nnoremap I :echo 'I disabled!'<CR>\" \
+    -c \"nnoremap a :echo 'a disabled!'<CR>\" \
+    -c \"nnoremap A :echo 'A disabled!'<CR>\" \
+    -c \"nnoremap p :echo 'p disabled!'<CR>\" \
+    -c \"nnoremap P :echo 'P disabled!'<CR>\" \
+    -c \"nnoremap q :q!<CR>\""
+
+# Using bat inside the terminal results in line wraps to dynamically adjust
+# when changing the windown size
+bat_options="\
+    --paging=always \
+    --style=plain"
+
+selected=$(cat ~/.config/tmux/.tmux-cht-languages ~/.config/tmux/.tmux-cht-command | $fuzzy_finder)
+
 if [[ -z $selected ]]; then
     exit 0
 fi
 
 read -p "Enter Query: " query
 
-if grep -qs "$selected" ~/.tmux-cht-languages; then
-    query=`echo $query | tr ' ' '+'`
-    tmux neww bash -c "echo \"curl cht.sh/$selected/$query/\" & curl cht.sh/$selected/$query & while [ : ]; do sleep 1; done"
+if grep -qs "$selected" ~/.config/tmux/.tmux-cht-languages; then
+    query=$(echo "$query" | tr ' ' '+')
+    url="cht.sh/$selected/$query"
 else
-    tmux neww bash -c "curl -s cht.sh/$selected~$query | less"
+    url="cht.sh/$selected~$query"
 fi
 
+tmux neww -n "$url" bash -c "nvim $nvim_options \
+    +'ter curl --no-progress-meter $url | bat $bat_options'"

--- a/bin/.local/scripts/tmux-cht.sh
+++ b/bin/.local/scripts/tmux-cht.sh
@@ -2,7 +2,6 @@
 
 # Prerequisites:
 # - fuzzy finder: either fzf or sk
-# - bat: as cat replacement - is being used as pager inside nvim terminal
 
 fuzzy_finder=fzf  # use either fzf or sk
 
@@ -11,16 +10,15 @@ fuzzy_finder=fzf  # use either fzf or sk
 nvim_options="\
     -c \"nnoremap q :q!<CR>\" \
     -c \"tnoremap <esc> :<C-\\><C-n>M\" \
-    -c \"tnoremap q :<C-\\><C-n>:q!<CR>\""
+    -c \"tnoremap q :<C-\\><C-n>:q!<CR>\" \
+    "
 
-# Using bat inside the terminal results in line wraps to dynamically adjust
-# when changing the windown size
-#bat_options=""
-bat_options="\
-    --paging=always \
-    --style=plain"
+less_options="-R"
 
-selected=$(cat ~/.config/tmux/.tmux-cht-languages ~/.config/tmux/.tmux-cht-command | $fuzzy_finder)
+selected=$(cat \
+    ~/.config/tmux/.tmux-cht-languages \
+    ~/.config/tmux/.tmux-cht-command | \
+    $fuzzy_finder)
 
 if [[ -z $selected ]]; then
     exit 0
@@ -36,5 +34,4 @@ else
 fi
 
 tmux neww -n "$url" bash -c "nvim $nvim_options \
-    +'ter curl --no-progress-meter $url | bat $bat_options'"  # +'call feedkeys(\"i\")'"
-
+    +'ter curl --no-progress-meter $url | less $less_options'"  # +'call feedkeys(\"i\")'"


### PR DESCRIPTION
This change allows to view the cht.sh results inside an nvim terminal making it easy to use all nvim movements including yank etc.

A few keymaps have also been changed (e.g. pressing q quits nvim inside this buffer).

The usage of less is a nice workaround to get line wraps to adjust when changing the window in which the nvim buffer opened.

I just changed these lines since I love to use nvim for almost everything (reading man pages and also as a pager).
Hopefully you will find that small adjustment useful. 