### PR TITLE
tmux-sessionizer: Another option for fixing it 

### DIFF
--- a/bin/.local/scripts/tmux-sessionizer
+++ b/bin/.local/scripts/tmux-sessionizer
@@ -11,15 +11,25 @@ if [[ -z $selected ]]; then
 fi
 
 selected_name=$(basename "$selected" | tr . _)
-tmux_running=$(pgrep tmux)
 
-if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
-    tmux new-session -s $selected_name -c $selected
-    exit 0
+# check if a session with the same name already exists
+existingSession=$(tmux list-sessions -F '#S' | grep "^$selected_name$")
+
+if [[ -z $TMUX ]]; then
+    # not in tmux session
+    if [[ -z $existingSession ]]; then
+        # session does not exist
+        tmux new-session -s $selected_name -c $selected
+    else
+        # session exists... attach to it
+        tmux attach -t $selected_name
+    fi
+else
+    # inside tmux session
+    if [[ -z $existingSession ]]; then
+        # session does not exist... create it
+        tmux new-session -d -s $selected_name -c $selected
+    fi
+        # switch to the session
+        tmux switch-client -t $selected_name
 fi
-
-if ! tmux has-session -t=$selected_name 2> /dev/null; then
-    tmux new-session -ds $selected_name -c $selected
-fi
-
-tmux switch-client -t $selected_name


### PR DESCRIPTION
- resolves the issue where the sessionizer doesn't jump into a tmux session when you're not already in one.
- cleans up the logic
-  inspired by Josh Medeski's [overly complicated sessionizer script](https://youtu.be/l_TTxc0AcCw?t=364)

I didn't realize there were already two other PRs for this. 
Here's a third option.