### PR TITLE
fix: tmux sessionizer now works when not attached

### DIFF
--- a/bin/.local/scripts/tmux-sessionizer
+++ b/bin/.local/scripts/tmux-sessionizer
@@ -13,13 +13,34 @@ fi
 selected_name=$(basename "$selected" | tr . _)
 tmux_running=$(pgrep tmux)
 
-if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
-    tmux new-session -s $selected_name -c $selected
+# tmux is not running
+if [[ -z $tmux_running ]]; then
+    tmux new-session -s $selected_name -c "$selected"
     exit 0
 fi
 
-if ! tmux has-session -t=$selected_name 2> /dev/null; then
-    tmux new-session -ds $selected_name -c $selected
+# tmux is running but client is not attached, session with selected_name does not exist
+if [[ -z $TMUX ]] && ! tmux has-session -t=$selected_name 2> /dev/null; then
+    tmux new-session -s $selected_name -c "$selected"
+    tmux a -t $selected_name
+    exit 0
 fi
 
-tmux switch-client -t $selected_name
+# tmux is running but client is not attached, session with selected_name exists
+if [[ -z $TMUX ]] && tmux has-session -t=$selected_name 2> /dev/null; then
+    tmux a -t $selected_name
+    exit 0
+fi
+
+# tmux is running and client is attached, session with selected_name does not exist
+if [[ ! -z $TMUX ]] && ! tmux has-session -t=$selected_name 2> /dev/null; then
+    tmux new-session -ds $selected_name -c "$selected"
+    tmux switch-client -t $selected_name
+    exit 0
+fi
+
+# tmux is running and client is attached, session with selected_name exists
+if [[ ! -z $TMUX ]] && tmux has-session -t=$selected_name 2> /dev/null; then
+    tmux switch-client -t $selected_name
+    exit 0
+fi


### PR DESCRIPTION
This PR fixes a bug that happens when you already have tmux running and you are not attached to it. I handled the following use cases:

- **tmux is not running:** script creates a new session with `new-session` and attaches to it
- **tmux is running but client is not attached and session with selected_name does not exist:** it creates the session and attaches to it
- **tmux is running but client is not attached, session with selected_name exists:** attaches to the session
- **tmux is running and client is attached, session with selected_name does not exist:** It creates a session with the `-d` flag (give them the d) and switches to it with `switch-client`
- **tmux is running and client is attached, session with selected_name exists:** it switches to the session with `switch-client`