### PR TITLE
fix: make tmux-cht.sh works correctly

### DIFF
--- a/bin/.local/scripts/tmux-cht.sh
+++ b/bin/.local/scripts/tmux-cht.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
-selected=`cat ~/.tmux-cht-languages ~/.tmux-cht-command | fzf`
+
+PAGER="less -r"
+selected=$(cat ~/.tmux-cht-languages ~/.tmux-cht-command | fzf)
+
 if [[ -z $selected ]]; then
     exit 0
 fi
 
-read -p "Enter Query: " query
+# -e Let you use arrow keys to correct query
+# -r Prevent \ to escape charecters
+read -rep "Enter Query: " query
 
 if grep -qs "$selected" ~/.tmux-cht-languages; then
-    query=`echo $query | tr ' ' '+'`
-    tmux neww bash -c "echo \"curl cht.sh/$selected/$query/\" & curl cht.sh/$selected/$query & while [ : ]; do sleep 1; done"
+    curl -s "cht.sh/$selected/${query//\ /\+}" | $PAGER
 else
-    tmux neww bash -c "curl -s cht.sh/$selected~$query | less"
+    # Allow empty query search
+    if [[ -n $query ]]; then
+        curl -s "cht.sh/$selected~$query" | $PAGER
+    else
+        curl -s "cht.sh/$selected" | $PAGER
+    fi
 fi
-


### PR DESCRIPTION
Hi,
I know you don't really care about form, especially on scripts, but I think that you should take a little of time to learn how to properly do some stuff in bash scripting because you teach some of this stuff in your paid courses... And the majority of your scripts have major bug or have a not very solid implementation.

An example:
```bash
tmux neww bash -c "echo \"curl cht.sh/$selected/$query/\" & curl cht.sh/$selected/$query & while [ : ]; do sleep 1; done"
```

You are trying to concatenate 2 commands one another and you are using the `&` operator. The `&` operator will execute a chain of command, but it will not respect the order. It will run the fastest first then the second fastest and so on. This is probably why you run the query two times, because you had found that sometimes it went to the loop without printing anything. The correct approach is using the `&&` operator witch will execute the second command only if the first one finished and succeded.

Also another thing don't use ` `` ` backticks for spawning a sub shell, use `$()` instead because the first method has been deprecated.

I doubt you are gonna listen to my advice but a great resource for learning *bash* scripting is the [bash bible](https://github.com/dylanaraps/pure-bash-bible) 