### PR TITLE
Update tmux-sessionizer

### DIFF
--- a/bin/.local/scripts/tmux-sessionizer
+++ b/bin/.local/scripts/tmux-sessionizer
@@ -18,6 +18,15 @@ if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
     exit 0
 fi
 
+if [[ -z $TMUX ]]; then
+	if ! tmux has-session -t=$selected_name 2>/dev/null; then
+		tmux new-session -s $selected_name -c $selected
+		exit 0
+	fi
+	tmux a -t $selected_name
+	exit 0
+fi
+
 if ! tmux has-session -t=$selected_name 2> /dev/null; then
     tmux new-session -ds $selected_name -c $selected
 fi


### PR DESCRIPTION
Tmux doesn't need to be currently attached if running in the background, will not show `no current client` error