### PR TITLE
tmux-sessionizer: Grab git projects under a wider set of folders

### DIFF
--- a/bin/.local/scripts/tmux-sessionizer
+++ b/bin/.local/scripts/tmux-sessionizer
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
+select-project() {
+    find ~/work ~/projects ~/personal -mindepth 2 -maxdepth 3 -iname '.git' -type d \
+        | sed -e 's/\/.git$//' \
+        | fzf
+}
+
 if [[ $# -eq 1 ]]; then
     selected=$1
 else
-    selected=$(find ~/work/builds ~/projects ~/ ~/work ~/personal ~/personal/yt -mindepth 1 -maxdepth 1 -type d | fzf)
+    selected=$(select-project)
 fi
 
 if [[ -z $selected ]]; then


### PR DESCRIPTION
This changes the set of projects which are surfaced to fzf in two ways:

* More subfolders are considered. (maxdepth is effectively increased by one.) This allows selecting from new category folders (e.g. ~/personal/yt) without modifying this script to explicitly mention each one.
 
* Projects which lack a .git folder will not be considered. This is mostly a positive thing, since it encourages us to use source control. However, it may remove important non-code folders from consideration.