### PR TITLE
Add realpath to parse session name correctly  and fix: add -u flag to write utf-8 characters to terminal

### DIFF
--- a/bin/.local/scripts/tmux-sessionizer
+++ b/bin/.local/scripts/tmux-sessionizer
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ $# -eq 1 ]]; then
-    selected=$1
+    selected=$(realpath $1)
 else
     selected=$(find ~/work/builds ~/projects ~/ ~/work ~/personal ~/personal/yt -mindepth 1 -maxdepth 1 -type d | fzf)
 fi
@@ -14,7 +14,7 @@ selected_name=$(basename "$selected" | tr . _)
 tmux_running=$(pgrep tmux)
 
 if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
-    tmux new-session -s $selected_name -c $selected
+    tmux new-session -u -s $selected_name -c $selected
     exit 0
 fi
 

--- a/bin/.local/scripts/tmux-sessionizer
+++ b/bin/.local/scripts/tmux-sessionizer
@@ -22,4 +22,9 @@ if ! tmux has-session -t=$selected_name 2> /dev/null; then
     tmux new-session -ds $selected_name -c $selected
 fi
 
+if [[ -z $TMUX ]]; then
+  tmux -u a
+  exit 0
+fi
+
 tmux switch-client -t $selected_name

--- a/bin/.local/scripts/tmux-sessionizer
+++ b/bin/.local/scripts/tmux-sessionizer
@@ -14,7 +14,7 @@ selected_name=$(basename "$selected" | tr . _)
 tmux_running=$(pgrep tmux)
 
 if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
-    tmux new-session -u -s $selected_name -c $selected
+    tmux -u new-session -s $selected_name -c $selected
     exit 0
 fi
 


### PR DESCRIPTION
Sometimes I'm in a directory in the terminal and I want to start tmux session from that directory. If I start a session using tmux-sessionizer using `tmux-sessionizer .` the session name becomes `.` 

Adding `realpath` will cause the `.` to expand and set the proper session name.

Also added ` -u`  flag to write utf-8 characters to the terminal when starting tmux if no client is already running. 